### PR TITLE
Add chant layout and consolidate chant scripts

### DIFF
--- a/_layouts/chant.html
+++ b/_layouts/chant.html
@@ -1,0 +1,7 @@
+---
+layout: single
+---
+
+{{ content }}
+
+<script src="/assets/js/chant.js"></script>

--- a/_posts/2025-07-28-ganaanaam-tva-ganapati.md
+++ b/_posts/2025-07-28-ganaanaam-tva-ganapati.md
@@ -1,4 +1,5 @@
 ---
+layout: chant
 Title: "Gananam Tva Ganapatim – Yajurveda Chant"
 Date: 2025-07-28
 Description: Learn the sacred Ganapati mantra from the Yajurveda with audio and guidance.
@@ -68,54 +69,17 @@ This chant is particularly suited for **initiating study, rituals, or spiritual 
 ---
 
 <script>
-function showDeva() {
-  document.getElementById('devanagari').style.display = 'block';
-  document.getElementById('iast').style.display = 'none';
-  document.getElementById('btn-deva').style.fontWeight = 'bold';
-  document.getElementById('btn-iast').style.fontWeight = 'normal';
-}
-function showIAST() {
-  document.getElementById('devanagari').style.display = 'none';
-  document.getElementById('iast').style.display = 'block';
-  document.getElementById('btn-deva').style.fontWeight = 'normal';
-  document.getElementById('btn-iast').style.fontWeight = 'bold';
-}
-</script>
-
-<script>
-const audio = document.querySelector('audio');
-const devanagariVisible = () => document.getElementById('devanagari').style.display !== 'none';
-const shouldScroll = () => document.getElementById('autoscroll-toggle')?.checked;
-
-
-audio.ontimeupdate = () => {
-  const t = audio.currentTime;
-
-  const lines = [
-    { id: 'line1', roman: 'line1-roman', start: 0, end: 12 },
-    { id: 'line2', roman: 'line2-roman', start: 12, end: 36 },
-    { id: 'line3', roman: 'line3-roman', start: 36, end: 61 },
-    { id: 'line4', roman: 'line4-roman', start: 61, end: 72 },
-    { id: 'line5', roman: 'line5-roman', start: 72, end: 89 },
-    { id: 'line6', roman: 'line6-roman', start: 89, end: 98 },
-    { id: 'line7', roman: 'line7-roman', start: 98, end: 118 },
-    { id: 'line8', roman: 'line8-roman', start: 118, end: 138 },
-    { id: 'line9', roman: 'line9-roman', start: 138, end: 148 }
-  ];
-
-  lines.forEach(({ id, roman, start, end }) => {
-    const visibleId = devanagariVisible() ? id : roman;
-    const el = document.getElementById(visibleId);
-    if (!el) return;
-
-    if (t >= start && t < end) {
-      el.style.backgroundColor = 'yellow';
-      
-    } else {
-      el.style.backgroundColor = '';
-    }
-  });
-};
+const lines = [
+  { id: 'line1', roman: 'line1-roman', start: 0, end: 12 },
+  { id: 'line2', roman: 'line2-roman', start: 12, end: 36 },
+  { id: 'line3', roman: 'line3-roman', start: 36, end: 61 },
+  { id: 'line4', roman: 'line4-roman', start: 61, end: 72 },
+  { id: 'line5', roman: 'line5-roman', start: 72, end: 89 },
+  { id: 'line6', roman: 'line6-roman', start: 89, end: 98 },
+  { id: 'line7', roman: 'line7-roman', start: 98, end: 118 },
+  { id: 'line8', roman: 'line8-roman', start: 118, end: 138 },
+  { id: 'line9', roman: 'line9-roman', start: 138, end: 148 }
+];
 </script>
 
 

--- a/_posts/2025-07-31-mahamrityunjaya.md
+++ b/_posts/2025-07-31-mahamrityunjaya.md
@@ -1,4 +1,5 @@
 ---
+layout: chant
 title: "Mahamrityunjaya Mantra"
 date: 2025-07-29
 description: Learn the sacred Mahamrityunjaya mantra with audio, Devanagari and IAST text.
@@ -49,42 +50,8 @@ The mantra is traditionally chanted 108 times, often using a Rudraksha mala (ros
 ---
 
 <script>
-function showDeva() {
-  document.getElementById('devanagari').style.display = 'block';
-  document.getElementById('iast').style.display = 'none';
-  document.getElementById('btn-deva').style.fontWeight = 'bold';
-  document.getElementById('btn-iast').style.fontWeight = 'normal';
-}
-function showIAST() {
-  document.getElementById('devanagari').style.display = 'none';
-  document.getElementById('iast').style.display = 'block';
-  document.getElementById('btn-deva').style.fontWeight = 'normal';
-  document.getElementById('btn-iast').style.fontWeight = 'bold';
-}
-</script>
-
-<script>
-const audio = document.querySelector('audio');
-const devanagariVisible = () => document.getElementById('devanagari').style.display !== 'none';
-
-audio.ontimeupdate = () => {
-  const t = audio.currentTime;
-
-  const lines = [
-    { id: 'line1', roman: 'line1-roman', start: 0, end: 6 },
-    { id: 'line2', roman: 'line2-roman', start: 6, end: 14 }
-  ];
-
-  lines.forEach(({ id, roman, start, end }) => {
-    const visibleId = devanagariVisible() ? id : roman;
-    const el = document.getElementById(visibleId);
-    if (!el) return;
-
-    if (t >= start && t < end) {
-      el.style.backgroundColor = 'yellow';
-    } else {
-      el.style.backgroundColor = '';
-    }
-  });
-};
+const lines = [
+  { id: 'line1', roman: 'line1-roman', start: 0, end: 6 },
+  { id: 'line2', roman: 'line2-roman', start: 6, end: 14 }
+];
 </script>

--- a/_posts/2025-08-01-nitya-paaraayana-shloka.md
+++ b/_posts/2025-08-01-nitya-paaraayana-shloka.md
@@ -1,4 +1,5 @@
 ---
+layout: chant
 title: "Nitya Paaraayana Shloka (Concluding Chant)"
 date: 2025-08-1
 description: Concluding excerpt from the Dasha‑Śānti mantra asking for forgiveness and peace.
@@ -51,17 +52,3 @@ This mantra closes the chanting session with reverence and a sense of inner comp
 
 ---
 
-<script>
-function showDeva() {
-  document.getElementById('devanagari').style.display = 'block';
-  document.getElementById('iast').style.display = 'none';
-  document.getElementById('btn-deva').style.fontWeight = 'bold';
-  document.getElementById('btn-iast').style.fontWeight = 'normal';
-}
-function showIAST() {
-  document.getElementById('devanagari').style.display = 'none';
-  document.getElementById('iast').style.display = 'block';
-  document.getElementById('btn-deva').style.fontWeight = 'normal';
-  document.getElementById('btn-iast').style.fontWeight = 'bold';
-}
-</script>

--- a/_posts/2025-08-04-durga-suktam.md
+++ b/_posts/2025-08-04-durga-suktam.md
@@ -1,4 +1,5 @@
 ---
+layout: chant
 title: "Durga Sūktam"
 date: 2025-07-31
 description: The Durga Sūkta with Devanāgarī / IAST toggle for study and chanting practice.
@@ -107,17 +108,3 @@ tanno durgiḥ pracodayāt||)</p>
 
 ---
 
-<script>
-function showDeva(){
-  document.getElementById('devanagari').style.display='block';
-  document.getElementById('iast').style.display='none';
-  document.getElementById('btn-deva').style.fontWeight='bold';
-  document.getElementById('btn-iast').style.fontWeight='normal';
-}
-function showIAST(){
-  document.getElementById('devanagari').style.display='none';
-  document.getElementById('iast').style.display='block';
-  document.getElementById('btn-deva').style.fontWeight='normal';
-  document.getElementById('btn-iast').style.fontWeight='bold';
-}
-</script>

--- a/assets/js/chant.js
+++ b/assets/js/chant.js
@@ -1,0 +1,35 @@
+function showDeva() {
+  document.getElementById('devanagari').style.display = 'block';
+  document.getElementById('iast').style.display = 'none';
+  document.getElementById('btn-deva').style.fontWeight = 'bold';
+  document.getElementById('btn-iast').style.fontWeight = 'normal';
+}
+
+function showIAST() {
+  document.getElementById('devanagari').style.display = 'none';
+  document.getElementById('iast').style.display = 'block';
+  document.getElementById('btn-deva').style.fontWeight = 'normal';
+  document.getElementById('btn-iast').style.fontWeight = 'bold';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const audio = document.querySelector('audio');
+  if (!audio || typeof lines === 'undefined') return;
+
+  const devanagariVisible = () =>
+    document.getElementById('devanagari').style.display !== 'none';
+
+  audio.ontimeupdate = () => {
+    const t = audio.currentTime;
+    lines.forEach(({ id, roman, start, end }) => {
+      const visibleId = devanagariVisible() ? id : roman;
+      const el = document.getElementById(visibleId);
+      if (!el) return;
+      if (t >= start && t < end) {
+        el.style.backgroundColor = 'yellow';
+      } else {
+        el.style.backgroundColor = '';
+      }
+    });
+  };
+});


### PR DESCRIPTION
## Summary
- Create a reusable `chant` layout extending the theme and loading a shared chant script
- Centralize Devanagari/IAST toggle and audio line-highlighting logic in `assets/js/chant.js`
- Update existing chant posts to use the new layout and remove duplicated inline scripts

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(command not found due to missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e3b9188833392bb1ec8a6b87779