### PR TITLE
Close code fence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ bundle install    # installs Jekyll
 # run site locally
 bundle exec jekyll serve
 # open http://localhost:4000 in your browser
+
+```


### PR DESCRIPTION
## Summary
- Close unclosed code block in `README.md` so local preview instructions render properly.

## Testing
- Attempted `bundle exec jekyll build` *(missing gem, installation failed: 403 Forbidden)*
- Rendered `README.md` with custom Python script to verify code block output.


------
https://chatgpt.com/codex/tasks/task_e_689b2a6cbcfc83339f0bb4f9b848f111